### PR TITLE
[Doc] Fix broken doc links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ If you want to use woqlDataframe:
 `python -m pip install git+https://github.com/terminusdb/terminusdb-client-python.git`
 
 ## Usage
-For the [full Documentation](https://terminusdb-client-python.readthedocs.io/)
+For the [full Documentation](https://terminusdb.github.io/terminusdb-client-python/)
 
 ## Tutorials
-Visit [terminus-tutorials](https://github.com/terminusdb/terminusdb-tutorials) for tutorial scripts
+Visit [terminus-tutorials](https://github.com/terminusdb/terminusdb-tutorials) for tutorial scripts and [Create TerminusDB Graph with Python Client](https://terminusdb.com/docs/getting-started/start-tutorials/py_client/) for a python-specific one.
 
 ## Testing
 * Clone this repository


### PR DESCRIPTION
This PR updates 2 broken links in the README file to point to the correct locations, and adds one to the python tutorial.
