### PR TITLE
[Bug] Fix references to 'ttype' parameter.

### DIFF
--- a/terminusdb_client/woqlclient/woqlClient.py
+++ b/terminusdb_client/woqlclient/woqlClient.py
@@ -400,14 +400,14 @@ class WOQLClient:
         '<account>/<db>/<repo>/branch/<branch>'
         """
         base = self.account() + "/" + self.db() + "/"
-        if type == "db":
+        if ttype == "db":
             return base
-        elif type == "meta":
+        elif ttype == "meta":
             return base + "_meta"
         base = base + self.repo()
-        if type == "repo":
+        if ttype == "repo":
             return base + "/_meta"
-        elif type == "commits":
+        elif ttype == "commits":
             return base + "/_commits"
         if val is None:
             if ttype == "ref":


### PR DESCRIPTION
This change fixes some typos referring to the `ttype` parameter as `type`.