### PR TITLE
[FIX] Removed the built-in len function used as condition

### DIFF
--- a/terminusdb_client/woqlquery/woql_query.py
+++ b/terminusdb_client/woqlquery/woql_query.py
@@ -482,7 +482,7 @@ class WOQLQuery:
     def _compile_path_pattern(self, pat):
         """Turns a textual path pattern into a JSON-LD description"""
         toks = _tokenize(pat)
-        if toks and toks:
+        if toks:
             return _tokens_to_json(toks, self)
         else:
             self._parameter_error("Pattern error - could not be parsed " + pat)

--- a/terminusdb_client/woqlquery/woql_query.py
+++ b/terminusdb_client/woqlquery/woql_query.py
@@ -482,7 +482,7 @@ class WOQLQuery:
     def _compile_path_pattern(self, pat):
         """Turns a textual path pattern into a JSON-LD description"""
         toks = _tokenize(pat)
-        if toks and len(toks):
+        if toks and toks:
             return _tokens_to_json(toks, self)
         else:
             self._parameter_error("Pattern error - could not be parsed " + pat)
@@ -3003,12 +3003,12 @@ class WOQLQuery:
                 graph,
             ),
         )
-        if len(subs):
+        if subs:
             if len(subs) == 1:
                 woql_filter.woql_and(subs[0])
             else:
                 woql_filter.woql_and(WOQLQuery().woql_or(*subs))
-        if len(nsubs):
+        if nsubs:
             woql_filter.woql_and(WOQLQuery().woql_and(*nsubs))
         cls = (
             WOQLQuery(graph=graph)


### PR DESCRIPTION
Using the `len` function to check if a sequence is empty is not idiomatic and can be less performant than checking the truthiness of the object.

`len` doesn't know the context in which it is called, so if computing the length means traversing the entire sequence, it must; it doesn't know that the result is just being compared to 0. Computing the boolean value can stop after it sees the first element, regardless of how long the sequence actually is.