### PR TITLE
Defunc rollback() and commit()

### DIFF
--- a/terminusdb_client/tests/integration_tests/test_client.py
+++ b/terminusdb_client/tests/integration_tests/test_client.py
@@ -21,11 +21,19 @@ def test_happy_path(docker_url):
     assert client._db == "test_happy_path"
     assert "test_happy_path" in client.list_databases()
     assert client._context.get("doc") == "foo://"
+    assert len(client.get_commit_history()) == 1
     # test adding doctype
     WOQLQuery().doctype("Station").execute(client)
     assert client._commit_made == 1
     first_commit = client._get_current_commit()
     assert first_commit != init_commit
+    commit_history = client.get_commit_history()
+    assert len(commit_history) == 2
+    assert len(client.get_commit_history(2)) == 2
+    assert len(client.get_commit_history(1)) == 1
+    assert len(client.get_commit_history(0)) == 1
+    assert commit_history[0]["commit"] == first_commit.split("_")[-1]
+    assert commit_history[1]["commit"] == init_commit.split("_")[-1]
     # test rollback
     client.rollback()
     assert client._commit_made == 0  # back to squre 1

--- a/terminusdb_client/tests/integration_tests/test_client.py
+++ b/terminusdb_client/tests/integration_tests/test_client.py
@@ -2,8 +2,6 @@ import csv
 import filecmp
 import os
 
-import pytest
-
 from terminusdb_client.woqlclient.woqlClient import WOQLClient
 from terminusdb_client.woqlquery.woql_query import WOQLQuery
 
@@ -24,7 +22,6 @@ def test_happy_path(docker_url):
     assert len(client.get_commit_history()) == 1
     # test adding doctype
     WOQLQuery().doctype("Station").execute(client)
-    assert client._commit_made == 1
     first_commit = client._get_current_commit()
     assert first_commit != init_commit
     commit_history = client.get_commit_history()
@@ -34,24 +31,6 @@ def test_happy_path(docker_url):
     assert len(client.get_commit_history(0)) == 1
     assert commit_history[0]["commit"] == first_commit.split("_")[-1]
     assert commit_history[1]["commit"] == init_commit.split("_")[-1]
-    # test rollback
-    client.rollback()
-    assert client._commit_made == 0  # back to squre 1
-    assert client._get_current_commit() == init_commit
-    # test rollback twice
-    WOQLQuery().doctype("Station").execute(client)
-    WOQLQuery().doctype("Journey").execute(client)
-    assert client._commit_made == 2
-    second_commit = client._get_current_commit()
-    assert second_commit != init_commit
-    client.rollback(2)
-    assert client._commit_made == 0  # back to squre 1
-    assert client._get_current_commit() == init_commit
-    # test rollback too much
-    WOQLQuery().doctype("Station").execute(client)
-    assert client._commit_made == 1
-    with pytest.raises(ValueError):
-        client.rollback(2)
     client.delete_database("test_happy_path", "admin")
     assert client._db is None
     assert "test_happy_path" not in client.list_databases()

--- a/terminusdb_client/tests/test_woqlClient.py
+++ b/terminusdb_client/tests/test_woqlClient.py
@@ -256,3 +256,11 @@ def test_delete_database(mocked_requests, mocked_requests2):
 
     with pytest.raises(UserWarning):
         woql_client.delete_database()
+
+
+@mock.patch("requests.get", side_effect=mocked_requests_get)
+def test_rollback(mocked_requests):
+    woql_client = WOQLClient("http://localhost:6363")
+    woql_client.connect(user="admin", account="admin", key="root")
+    with pytest.raises(NotImplementedError):
+        woql_client.rollback()

--- a/terminusdb_client/tests/test_woqlClient.py
+++ b/terminusdb_client/tests/test_woqlClient.py
@@ -220,11 +220,10 @@ def test_query_nodb(mocked_requests):
 
 @mock.patch("requests.get", side_effect=mocked_requests_get)
 @mock.patch.object(WOQLClient, "_dispatch_json")
-def test_query_commit_count(mocked_execute, mocked_requests):
+def test_query_commit_made(mocked_execute, mocked_requests):
     # mocked_execute.return_value = MOCK_CAPABILITIES
     woql_client = WOQLClient("http://localhost:6363")
     woql_client.connect(user="admin", account="admin", key="root", db="myDBName")
-    assert woql_client._commit_made == 0
     mocked_execute.return_value = {
         "@type": "api:WoqlResponse",
         "api:status": "api:success",
@@ -234,10 +233,8 @@ def test_query_commit_count(mocked_execute, mocked_requests):
         "inserts": 1,
         "transaction_retry_count": 0,
     }
-    woql_client.query(WoqlStar)
-    assert woql_client._commit_made == 1
-    woql_client.commit(WoqlStar)
-    assert woql_client._commit_made == 0
+    result = woql_client.query(WoqlStar)
+    assert result == "Commit successfully made."
 
 
 @mock.patch("requests.post", side_effect=mocked_requests_get)

--- a/terminusdb_client/woqlclient/woqlClient.py
+++ b/terminusdb_client/woqlclient/woqlClient.py
@@ -1039,7 +1039,6 @@ class WOQLClient:
 
     def commit(self):
         """Not implementated: open transections currently not suportted. Please check back later."""
-        return result
 
     def query(
         self,

--- a/terminusdb_client/woqlclient/woqlClient.py
+++ b/terminusdb_client/woqlclient/woqlClient.py
@@ -251,27 +251,17 @@ class WOQLClient:
         return target_commit
 
     def rollback(self, steps=1) -> None:
-        """Rollback number of update queries set in steps.
+        """Curently not implementated. Please check back later.
 
-        Steps need to be smaller than the number of update queries made in the session. Number of update queries made in the session is counted from the last connection or commit() call.
-
-        Parameters
+        Raises
         ----------
-        steps: int
-            Number of update queries to rollback.
+        NotImplementedError
+            Since TerminusDB currently does not support open transessions. This method is not applicable to it's usage. To reset commit head, use WOQLClient.reset
 
-        Returns
-        -------
-        None
         """
-        self._check_connection()
-        if steps > self._commit_made:
-            raise ValueError(
-                f"Cannot rollback before the lst connection or commit call. Number of update queries made that can be rollback: {self._commit_made}"
-            )
-        target_commit = self._get_target_commit(steps)
-        self._commit_made -= steps
-        self.reset(f"{self._account}/{self._db}/{self._repo}/commit/{target_commit}")
+        raise NotImplementedError(
+            "Open transections are currently not supported. To reset commit head, check WOQLClient.reset"
+        )
 
     def copy(self) -> "WOQLClient":
         """Create a deep copy of this client.

--- a/terminusdb_client/woqlclient/woqlClient.py
+++ b/terminusdb_client/woqlclient/woqlClient.py
@@ -1051,29 +1051,8 @@ class WOQLClient:
             file_list=csv_paths_list,
         )
 
-    def commit(
-        self,
-        woql_query: Union[dict, WOQLQuery],
-        commit_msg: Optional[str] = None,
-        file_dict: Optional[dict] = None,
-    ):
-        """Updates the contents of the specified graph with the triples encoded in turtle format Replaces the entire graph contents and locking the commits so it cannot be rollback further than this point with the same client objcet.
-
-        Parameters
-        ----------
-        woql_query : dict or WOQLQuery object
-            A woql query as an object or dict
-        commit_mg : str
-            A message that will be written to the commit log to describe the change
-        file_dict:
-            File dictionary to be associated with post name => filename, for multipart POST
-
-        Examples
-        -------
-        >>> WOQLClient(server="http://localhost:6363").commit(woql, "updating graph")
-        """
-        result = self.query(woql_query, commit_msg, file_dict)
-        self._commit_made = 0
+    def commit(self):
+        """Not implementated: open transections currently not suportted. Please check back later."""
         return result
 
     def query(

--- a/terminusdb_client/woqlclient/woqlClient.py
+++ b/terminusdb_client/woqlclient/woqlClient.py
@@ -40,7 +40,6 @@ class WOQLClient:
         self._api = f"{self._server_url}/api"
         self._connected = False
         self.insecure = insecure
-        self._commit_made = 0
 
     def connect(
         self,
@@ -108,8 +107,6 @@ class WOQLClient:
 
         if self._db is not None:
             self._context = self._get_prefixes()
-
-        self._commit_made = 0
 
     def close(self) -> None:
         """Undo connect and close the connection.
@@ -705,7 +702,6 @@ class WOQLClient:
 
         self._account = accountid
         self._connected = True
-        self._commit_made = 0
         self._db = dbid
         self._dispatch("post", self._db_url(), details)
         self._context = self._get_prefixes()
@@ -1110,7 +1106,6 @@ class WOQLClient:
             file_list,
         )
         if result.get("inserts") or result.get("deletes"):
-            self._commit_made += 1
             return "Commit successfully made."
         return result
 

--- a/terminusdb_client/woqlclient/woqlClient.py
+++ b/terminusdb_client/woqlclient/woqlClient.py
@@ -253,11 +253,11 @@ class WOQLClient:
         Raises
         ----------
         NotImplementedError
-            Since TerminusDB currently does not support open transessions. This method is not applicable to it's usage. To reset commit head, use WOQLClient.reset
+            Since TerminusDB currently does not support open transactions. This method is not applicable to it's usage. To reset commit head, use WOQLClient.reset
 
         """
         raise NotImplementedError(
-            "Open transections are currently not supported. To reset commit head, check WOQLClient.reset"
+            "Open transactions are currently not supported. To reset commit head, check WOQLClient.reset"
         )
 
     def copy(self) -> "WOQLClient":
@@ -1038,7 +1038,7 @@ class WOQLClient:
         )
 
     def commit(self):
-        """Not implementated: open transections currently not suportted. Please check back later."""
+        """Not implementated: open transactions currently not suportted. Please check back later."""
 
     def query(
         self,

--- a/terminusdb_client/woqldataframe/woqlDataframe.py
+++ b/terminusdb_client/woqldataframe/woqlDataframe.py
@@ -1,17 +1,20 @@
 # woqlDataframe.py
 
 import warnings
+from importlib import import_module
 
-try:
-    import numpy as np
-    import pandas as pd
-except ImportError:
-    msg = (
-        "woqlDataframe requirements are not installed.\n\n"
-        "If you want to use woqlDataframe, please pip install as follows:\n\n"
-        "  python -m pip install -U terminus-client-python[dataframe]"
-    )
-    warnings.warn(msg)
+
+def _import_needed(package):
+    try:
+        module = import_module(package)
+        return module
+    except ImportError:
+        msg = (
+            "woqlDataframe requirements are not installed.\n\n"
+            "If you want to use woqlDataframe, please pip install as follows:\n\n"
+            "  python -m pip install -U terminus-client-python[dataframe]"
+        )
+        raise ImportError(msg)
 
 
 class EmptyException(Exception):
@@ -163,6 +166,7 @@ def type_map(ty_rdf):
     query_to_df : put the result of the query into a pandas DataFrame
     type_value_map : converts values of different WOQL rdf types to numpy data types values
     """
+    np = _import_needed("numpy")
     convert_mapping = {
         "http://www.w3.org/2001/XMLSchema#string": np.unicode_,
         "http://www.w3.org/2001/XMLSchema#integer": np.int,
@@ -203,6 +207,7 @@ def type_value_map(ty_rdf, value):
     query_to_df : put the result of the query into a pandas DataFrame
     type_map : mapping types from WOQL rdf to numpy data types
     """
+    np = _import_needed("numpy")
     if ty_rdf == "http://www.w3.org/2001/XMLSchema#string":
         return value
     elif ty_rdf == "http://www.w3.org/2001/XMLSchema#integer":
@@ -282,6 +287,7 @@ def result_to_df(query):
     WOQLQuery : create a WOQLQuery
     WOQLClient : create a WOQLClient
     """
+    pd = _import_needed("pandas")
     header = extract_header(query)
     dtypes = {}
     column_names = []


### PR DESCRIPTION
Fix up rollback and commit according to #182. This PR address item 1,2 in:

1) commit return pass
2) rollback raise a not supported error (to deprecated the old implementation)
3) #183 
4) reset can take in a commit id and with a flag to switch to taking in a path

_Originally posted by @Cheukting in https://github.com/terminusdb/terminusdb-client-python/issues/182#issuecomment-804138356_
