### PR TITLE
Dynamically import pandas and numpy in WOQLDataframe

### DIFF
--- a/terminusdb_client/woqldataframe/woqlDataframe.py
+++ b/terminusdb_client/woqldataframe/woqlDataframe.py
@@ -1,5 +1,6 @@
 # woqlDataframe.py
 
+import warnings
 from importlib import import_module
 
 

--- a/terminusdb_client/woqldataframe/woqlDataframe.py
+++ b/terminusdb_client/woqldataframe/woqlDataframe.py
@@ -1,20 +1,19 @@
 # woqlDataframe.py
 
-import warnings
 from importlib import import_module
 
 
 def _import_needed(package):
     try:
         module = import_module(package)
+        return module
     except ImportError:
         msg = (
             "woqlDataframe requirements are not installed.\n\n"
             "If you want to use woqlDataframe, please pip install as follows:\n\n"
             "  python -m pip install -U terminus-client-python[dataframe]"
         )
-        warnings.warn(msg)
-    return module
+        raise ImportError(msg)
 
 
 class EmptyException(Exception):

--- a/terminusdb_client/woqldataframe/woqlDataframe.py
+++ b/terminusdb_client/woqldataframe/woqlDataframe.py
@@ -1,17 +1,20 @@
 # woqlDataframe.py
 
 import warnings
+from importlib import import_module
 
-try:
-    import numpy as np
-    import pandas as pd
-except ImportError:
-    msg = (
-        "woqlDataframe requirements are not installed.\n\n"
-        "If you want to use woqlDataframe, please pip install as follows:\n\n"
-        "  python -m pip install -U terminus-client-python[dataframe]"
-    )
-    warnings.warn(msg)
+
+def _import_needed(package):
+    try:
+        module = import_module(package)
+    except ImportError:
+        msg = (
+            "woqlDataframe requirements are not installed.\n\n"
+            "If you want to use woqlDataframe, please pip install as follows:\n\n"
+            "  python -m pip install -U terminus-client-python[dataframe]"
+        )
+        warnings.warn(msg)
+    return module
 
 
 class EmptyException(Exception):
@@ -163,6 +166,7 @@ def type_map(ty_rdf):
     query_to_df : put the result of the query into a pandas DataFrame
     type_value_map : converts values of different WOQL rdf types to numpy data types values
     """
+    np = _import_needed("numpy")
     convert_mapping = {
         "http://www.w3.org/2001/XMLSchema#string": np.unicode_,
         "http://www.w3.org/2001/XMLSchema#integer": np.int,
@@ -203,6 +207,7 @@ def type_value_map(ty_rdf, value):
     query_to_df : put the result of the query into a pandas DataFrame
     type_map : mapping types from WOQL rdf to numpy data types
     """
+    np = _import_needed("numpy")
     if ty_rdf == "http://www.w3.org/2001/XMLSchema#string":
         return value
     elif ty_rdf == "http://www.w3.org/2001/XMLSchema#integer":
@@ -282,6 +287,7 @@ def result_to_df(query):
     WOQLQuery : create a WOQLQuery
     WOQLClient : create a WOQLClient
     """
+    pd = _import_needed("pandas")
     header = extract_header(query)
     dtypes = {}
     column_names = []


### PR DESCRIPTION
Close #179

To get rid of the import warning if not using WOQLDataframe, which contain optional dependency pandas and numpy. Now, these packages will only be imported during function calls and if the package does not exist, it will raise an exception with the custom warning message.
