### PR TITLE
[Bug] Fix context under db creation (Close #207)

### DIFF
--- a/terminusdb_client/tests/mockResponse.py
+++ b/terminusdb_client/tests/mockResponse.py
@@ -77,6 +77,12 @@
 #
 #     return MockResponse(args[0], 200, APIEndpointConst.CONNECT)
 
+HEADERS = {
+    "date": None,
+    "connection": "keep-alive",
+    "content-type": "application/json",
+    "content-length": "252",
+}
 
 MOCK_CAPABILITIES = {
     "@context": {

--- a/terminusdb_client/woqlclient/woqlClient.py
+++ b/terminusdb_client/woqlclient/woqlClient.py
@@ -725,8 +725,10 @@ class WOQLClient:
         self._account = accountid
         self._connected = True
         self._db = dbid
-        self._dispatch("post", self._db_url(), details)
-        self._context = self._get_prefixes()
+        try:
+            self._dispatch("post", self._db_url(), details)
+        finally:
+            self._context = self._get_prefixes()
 
     def delete_database(
         self,


### PR DESCRIPTION
Addressing #207

Modified `mocked_requests_get()` to return function to be able to override response code like
`@mock.patch("requests.post", side_effect=mocked_request(response_code=400))`