### PR TITLE
[Feature] Dockerfile for terminusdb-python

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:latest AS build
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python3 pip
+
+RUN mkdir -p /build
+COPY Pipfile makefile pytest.ini requirements-dev.in requirements.in setup.cfg setup.py tox.ini README.md /build/
+COPY terminusdb_client /build/terminusdb_client
+WORKDIR /build
+
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install pipenv --upgrade
+RUN pipenv install --dev --pre
+RUN python3 -m pip install -e .
+
+RUN useradd -g 1000 -u 1000 -m user
+RUN mkdir /tdb
+RUN chown user /tdb
+COPY docker/run.sh /bin/run.sh
+
+USER user
+WORKDIR /tdb
+
+ENTRYPOINT ["/bin/run.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,25 @@
+# Dockerized python client
+
+```
+DOCKER_USER=terminusdb
+DOCKER_IMAGENAME=$DOCKER_USER/terminusdb-python
+
+docker build --pull -t "$DOCKER_IMAGENAME" -f docker/Dockerfile .
+docker push "$DOCKER_IMAGENAME"
+
+docker run --rm -it -v $PWD/tdb:/tdb "$DOCKER_IMAGENAME" startproject
+# https://cloud.terminusdb.com
+# Enter your teamname on TerminusX
+# JWT token must be used with environment variable instead 
+
+TERMINUSDB_ACCESS_TOKEN=ey... # Insert terminusX access token here
+docker run --rm -it -e TERMINUSDB_ACCESS_TOKEN=$TERMINUSDB_ACCESS_TOKEN -v $PWD/tdb:/tdb "$DOCKER_IMAGENAME" commit
+```
+
+You can also use an alias like so (note that tdb will be created automatically in your home directory):
+You may also need to make the folder writable to the in-docker user (uid 1000, gid 1000)
+```
+mkdir $HOME/tdb
+TERMINUSDB_ACCESS_TOKEN=ey...
+alias terminusdb='docker run --rm -it -e TERMINUSDB_ACCESS_TOKEN=$TERMINUSDB_ACCESS_TOKEN -v $HOME/tdb:/tdb "$DOCKER_IMAGENAME"'
+```

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ -z "$1" ] && exec /usr/bin/python3
+
+exec /usr/local/bin/terminusdb "$@"


### PR DESCRIPTION
The Dockerfile has an accompanying README.md file to show how to use it.

A provisional image of it is available at `hoijnet/terminusdb`. Should you accept the PR and an official image would be created, it would be awesome and make the terminusdb client more available to be used even without installing python directly.

The client can be started without arguments, launching python3 where the client can be loaded, or with the regular arguments to load the schema and such.

Hope it's helpful :-) 
