### PR TITLE
Allow click 8.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ for old_str, new_str in replace_pairs.items():
 
 # ---
 
-requires = ["requests", "numpydoc", "click<8.0,>=7.0", "shed", "typeguard", "tqdm"]
+requires = ["requests", "numpydoc", "click>=7.0", "shed", "typeguard", "tqdm"]
 
 extras_require = {"dataframe": ["numpy >= 1.13.0", "pandas >= 0.23.0"]}
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ for old_str, new_str in replace_pairs.items():
 
 # ---
 
-requires = ["requests", "numpydoc", "click>=7.0", "shed", "typeguard", "tqdm"]
+requires = ["requests", "numpydoc", "click<9.0,>=7.0", "shed", "typeguard", "tqdm"]
 
 extras_require = {"dataframe": ["numpy >= 1.13.0", "pandas >= 0.23.0"]}
 


### PR DESCRIPTION
[The latest stable version (22.1.0) of the `black` python code formatter requires click>=8.0.0](https://github.com/psf/black/blob/22.1.0/setup.py#L100), whereas `terminusdb-client-python` requires click<8.0. This means I can't have the latest `black` and `terminusdb-client-python` installed in my project.

I ran the tests with click==8.0.4, and they all pass on my local machine, but 6 tests were skipped because I don't have a valid TERMINUSX_TOKEN set. I tried generating one at https://dashboard.terminusdb.com/profile but this did not work, so I'm skipping those tests. Hopefully they are not dependent on click<8.0.


