### PR TITLE
User agent refactor and override option

### DIFF
--- a/terminusdb_client/tests/integration_tests/test_client.py
+++ b/terminusdb_client/tests/integration_tests/test_client.py
@@ -98,8 +98,12 @@ def test_diff_ops(docker_url, test_schema):
     client = WOQLClient(docker_url, user_agent=test_user_agent)
     client.connect()
     client.create_database("test_diff_ops")
-    public_diff = WOQLClient("https://cloud.terminusdb.com/jsondiff", user_agent=test_user_agent)
-    public_patch = WOQLClient("https://cloud.terminusdb.com/jsonpatch", user_agent=test_user_agent)
+    public_diff = WOQLClient(
+        "https://cloud.terminusdb.com/jsondiff", user_agent=test_user_agent
+    )
+    public_patch = WOQLClient(
+        "https://cloud.terminusdb.com/jsonpatch", user_agent=test_user_agent
+    )
 
     result_patch = Patch(
         json='{"@id": "Person/Jane", "name" : { "@op" : "SwapValue", "@before" : "Jane", "@after": "Janine" }}'
@@ -140,7 +144,9 @@ def test_diff_ops(docker_url, test_schema):
     new_data_version = client.get_document(jane_id, get_data_version=True)[-1]
     new_commit = client._get_current_commit()
     commit_id_result2 = client.diff(current_commit, new_commit, document_id=jane_id)
-    data_version_result2 = client.diff(data_version, new_data_version, document_id=jane_id)
+    data_version_result2 = client.diff(
+        data_version, new_data_version, document_id=jane_id
+    )
     # test all diff commit_id and data_version
     commit_id_result_all = client.diff(current_commit, new_commit)
     data_version_result_all = client.diff(data_version, new_data_version)
@@ -208,7 +214,9 @@ def test_diff_ops(docker_url, test_schema):
 )
 def test_diff_ops_no_auth(test_schema, terminusx_token):
     # create client and db
-    client = WOQLClient("https://cloud-dev.terminusdb.com/TerminusDBTest//", user_agent=test_user_agent)
+    client = WOQLClient(
+        "https://cloud-dev.terminusdb.com/TerminusDBTest//", user_agent=test_user_agent
+    )
     client.connect(use_token=True, team="TerminusDBTest")
 
     result_patch = Patch(

--- a/terminusdb_client/tests/integration_tests/test_client.py
+++ b/terminusdb_client/tests/integration_tests/test_client.py
@@ -12,18 +12,20 @@ from terminusdb_client.woqlquery.woql_query import WOQLQuery
 
 # from terminusdb_client.woqlquery.woql_query import WOQLQuery
 
+test_user_agent = "terminusdb-client-python-tests"
+
 
 def test_happy_path(docker_url):
     # create client
     client = WOQLClient(docker_url)
     assert not client._connected
     # test connect
-    client.connect()
+    client.connect(user_agent=test_user_agent)
     assert client._connected
     assert client._db_info is not None
     # test db does not exist
     with pytest.raises(InterfaceError) as error:
-        client.connect(db="test_happy_path")
+        client.connect(db="test_happy_path", user_agent=test_user_agent)
         assert error.value == "Connection fail, test_happy_path does not exist."
     # test create db
     client.create_database("test_happy_path")
@@ -63,7 +65,7 @@ def test_happy_carzy_path(docker_url):
     client = WOQLClient(docker_url)
     assert not client._connected
     # test connect
-    client.connect()
+    client.connect(user_agent=test_user_agent)
     assert client._connected
     # test create db
     client.create_database("test happy path")
@@ -94,7 +96,7 @@ def test_happy_carzy_path(docker_url):
 def test_diff_ops(docker_url, test_schema):
     # create client and db
     client = WOQLClient(docker_url)
-    client.connect()
+    client.connect(user_agent=test_user_agent)
     client.create_database("test_diff_ops")
     public_diff = WOQLClient("https://cloud.terminusdb.com/jsondiff")
     public_patch = WOQLClient("https://cloud.terminusdb.com/jsonpatch")
@@ -207,7 +209,7 @@ def test_diff_ops(docker_url, test_schema):
 def test_diff_ops_no_auth(test_schema, terminusx_token):
     # create client and db
     client = WOQLClient("https://cloud-dev.terminusdb.com/TerminusDBTest//")
-    client.connect(use_token=True, team="TerminusDBTest")
+    client.connect(use_token=True, team="TerminusDBTest", user_agent=test_user_agent)
 
     result_patch = Patch(
         json='{"@id": "Person/Jane", "name" : { "@op" : "SwapValue", "@before" : "Jane", "@after": "Janine" }}'
@@ -255,7 +257,7 @@ def test_jwt(docker_url_jwt):
     client = WOQLClient(url)
     assert not client._connected
     # test connect
-    client.connect(use_token=True, jwt_token=token)
+    client.connect(use_token=True, jwt_token=token, user_agent=test_user_agent)
     assert client._connected
     # test create db
     client.create_database("test_happy_path")
@@ -275,7 +277,7 @@ def test_terminusx(terminusx_token):
     )
     endpoint = "https://cloud-dev.terminusdb.com/TerminusDBTest/"
     client = WOQLClient(endpoint)
-    client.connect(use_token=True, team="TerminusDBTest")
+    client.connect(use_token=True, team="TerminusDBTest", user_agent=test_user_agent)
     assert client._connected
     # test create db
     client.create_database(testdb)
@@ -293,7 +295,7 @@ def test_terminusx_crazy_path(terminusx_token):
     testdb = "test happy_" + str(dt.datetime.now()).replace(" ", "")
     endpoint = "https://cloud-dev.terminusdb.com/TerminusDBTest/"
     client = WOQLClient(endpoint)
-    client.connect(use_token=True, team="TerminusDBTest")
+    client.connect(use_token=True, team="TerminusDBTest", user_agent=test_user_agent)
     assert client._connected
     # test create db
     client.create_database(testdb)

--- a/terminusdb_client/tests/integration_tests/test_client.py
+++ b/terminusdb_client/tests/integration_tests/test_client.py
@@ -17,15 +17,15 @@ test_user_agent = "terminusdb-client-python-tests"
 
 def test_happy_path(docker_url):
     # create client
-    client = WOQLClient(docker_url)
+    client = WOQLClient(docker_url, user_agent=test_user_agent)
     assert not client._connected
     # test connect
-    client.connect(user_agent=test_user_agent)
+    client.connect()
     assert client._connected
     assert client._db_info is not None
     # test db does not exist
     with pytest.raises(InterfaceError) as error:
-        client.connect(db="test_happy_path", user_agent=test_user_agent)
+        client.connect(db="test_happy_path")
         assert error.value == "Connection fail, test_happy_path does not exist."
     # test create db
     client.create_database("test_happy_path")
@@ -62,10 +62,10 @@ def test_happy_path(docker_url):
 
 def test_happy_carzy_path(docker_url):
     # create client
-    client = WOQLClient(docker_url)
+    client = WOQLClient(docker_url, user_agent=test_user_agent)
     assert not client._connected
     # test connect
-    client.connect(user_agent=test_user_agent)
+    client.connect()
     assert client._connected
     # test create db
     client.create_database("test happy path")
@@ -95,11 +95,11 @@ def test_happy_carzy_path(docker_url):
 
 def test_diff_ops(docker_url, test_schema):
     # create client and db
-    client = WOQLClient(docker_url)
-    client.connect(user_agent=test_user_agent)
+    client = WOQLClient(docker_url, user_agent=test_user_agent)
+    client.connect()
     client.create_database("test_diff_ops")
-    public_diff = WOQLClient("https://cloud.terminusdb.com/jsondiff")
-    public_patch = WOQLClient("https://cloud.terminusdb.com/jsonpatch")
+    public_diff = WOQLClient("https://cloud.terminusdb.com/jsondiff", user_agent=test_user_agent)
+    public_patch = WOQLClient("https://cloud.terminusdb.com/jsonpatch", user_agent=test_user_agent)
 
     result_patch = Patch(
         json='{"@id": "Person/Jane", "name" : { "@op" : "SwapValue", "@before" : "Jane", "@after": "Janine" }}'
@@ -208,8 +208,8 @@ def test_diff_ops(docker_url, test_schema):
 )
 def test_diff_ops_no_auth(test_schema, terminusx_token):
     # create client and db
-    client = WOQLClient("https://cloud-dev.terminusdb.com/TerminusDBTest//")
-    client.connect(use_token=True, team="TerminusDBTest", user_agent=test_user_agent)
+    client = WOQLClient("https://cloud-dev.terminusdb.com/TerminusDBTest//", user_agent=test_user_agent)
+    client.connect(use_token=True, team="TerminusDBTest")
 
     result_patch = Patch(
         json='{"@id": "Person/Jane", "name" : { "@op" : "SwapValue", "@before" : "Jane", "@after": "Janine" }}'
@@ -254,10 +254,10 @@ def test_jwt(docker_url_jwt):
     # create client
     url = docker_url_jwt[0]
     token = docker_url_jwt[1]
-    client = WOQLClient(url)
+    client = WOQLClient(url, user_agent=test_user_agent)
     assert not client._connected
     # test connect
-    client.connect(use_token=True, jwt_token=token, user_agent=test_user_agent)
+    client.connect(use_token=True, jwt_token=token)
     assert client._connected
     # test create db
     client.create_database("test_happy_path")
@@ -276,8 +276,8 @@ def test_terminusx(terminusx_token):
         "test_happy_" + str(dt.datetime.now()).replace(" ", "") + "_" + str(random())
     )
     endpoint = "https://cloud-dev.terminusdb.com/TerminusDBTest/"
-    client = WOQLClient(endpoint)
-    client.connect(use_token=True, team="TerminusDBTest", user_agent=test_user_agent)
+    client = WOQLClient(endpoint, user_agent=test_user_agent)
+    client.connect(use_token=True, team="TerminusDBTest")
     assert client._connected
     # test create db
     client.create_database(testdb)
@@ -294,8 +294,8 @@ def test_terminusx(terminusx_token):
 def test_terminusx_crazy_path(terminusx_token):
     testdb = "test happy_" + str(dt.datetime.now()).replace(" ", "")
     endpoint = "https://cloud-dev.terminusdb.com/TerminusDBTest/"
-    client = WOQLClient(endpoint)
-    client.connect(use_token=True, team="TerminusDBTest", user_agent=test_user_agent)
+    client = WOQLClient(endpoint, user_agent=test_user_agent)
+    client.connect(use_token=True, team="TerminusDBTest")
     assert client._connected
     # test create db
     client.create_database(testdb)

--- a/terminusdb_client/tests/integration_tests/test_schema.py
+++ b/terminusdb_client/tests/integration_tests/test_schema.py
@@ -11,8 +11,8 @@ test_user_agent = "terminusdb-client-python-tests"
 
 def test_create_schema(docker_url, test_schema):
     my_schema = test_schema
-    client = WOQLClient(docker_url)
-    client.connect(user_agent=test_user_agent)
+    client = WOQLClient(docker_url, user_agent=test_user_agent)
+    client.connect()
     client.create_database("test_docapi")
     client.insert_document(
         my_schema, commit_msg="I am checking in the schema", graph_type="schema"
@@ -37,8 +37,8 @@ def test_create_schema(docker_url, test_schema):
 
 def test_create_schema2(docker_url, test_schema):
     my_schema = test_schema
-    client = WOQLClient(docker_url)
-    client.connect(user_agent=test_user_agent)
+    client = WOQLClient(docker_url, user_agent=test_user_agent)
+    client.connect()
     client.create_database("test_docapi2")
     my_schema.commit(client, "I am checking in the schema")
     result = client.get_all_documents(graph_type="schema")
@@ -86,8 +86,8 @@ def test_insert_cheuk(docker_url, test_schema):
     cheuk.friend_of = {cheuk}
     cheuk.member_of = Team.IT
 
-    client = WOQLClient(docker_url)
-    client.connect(db="test_docapi", user_agent=test_user_agent)
+    client = WOQLClient(docker_url, user_agent=test_user_agent)
+    client.connect(db="test_docapi")
     # client.create_database("test_docapi")
     # print(cheuk._obj_to_dict())
     with pytest.raises(ValueError) as error:
@@ -127,8 +127,8 @@ def test_insert_cheuk(docker_url, test_schema):
 def test_getting_and_deleting_cheuk(docker_url):
     assert "cheuk" not in globals()
     assert "cheuk" not in locals()
-    client = WOQLClient(docker_url)
-    client.connect(db="test_docapi", user_agent=test_user_agent)
+    client = WOQLClient(docker_url, user_agent=test_user_agent)
+    client.connect(db="test_docapi")
     new_schema = WOQLSchema()
     new_schema.from_db(client)
     cheuk = new_schema.import_objects(
@@ -146,8 +146,8 @@ def test_getting_and_deleting_cheuk(docker_url):
 
 
 def test_insert_cheuk_again(docker_url, test_schema):
-    client = WOQLClient(docker_url)
-    client.connect(db="test_docapi", user_agent=test_user_agent)
+    client = WOQLClient(docker_url, user_agent=test_user_agent)
+    client.connect(db="test_docapi")
     new_schema = WOQLSchema()
     new_schema.from_db(client)
     uk = new_schema.import_objects(client.get_document("Country/United%20Kingdom"))
@@ -222,8 +222,8 @@ def test_insert_cheuk_again(docker_url, test_schema):
 
 
 def test_get_data_version(docker_url):
-    client = WOQLClient(docker_url)
-    client.connect(db="test_docapi", user_agent=test_user_agent)
+    client = WOQLClient(docker_url, user_agent=test_user_agent)
+    client.connect(db="test_docapi")
     result, version = client.get_all_branches(get_data_version=True)
     assert version
     result, version = client.get_all_documents(
@@ -302,8 +302,8 @@ def test_datetime_backend(docker_url):
         weeks=2,
     )
     test_obj = CheckDatetime(datetime=datetime_obj, duration=delta)
-    client = WOQLClient(docker_url)
-    client.connect(user_agent=test_user_agent)
+    client = WOQLClient(docker_url, user_agent=test_user_agent)
+    client.connect()
     client.create_database("test_datetime")
     client.insert_document(CheckDatetime, graph_type="schema")
     client.insert_document(test_obj)
@@ -321,8 +321,8 @@ def test_compress_data(docker_url):
         weeks=2,
     )
     test_obj = [CheckDatetime(datetime=datetime_obj, duration=delta) for _ in range(10)]
-    client = WOQLClient(docker_url)
-    client.connect(user_agent=test_user_agent)
+    client = WOQLClient(docker_url, user_agent=test_user_agent)
+    client.connect()
     client.create_database("test_compress_data")
     client.insert_document(CheckDatetime, graph_type="schema")
     client.insert_document(test_obj, compress=0)

--- a/terminusdb_client/tests/integration_tests/test_schema.py
+++ b/terminusdb_client/tests/integration_tests/test_schema.py
@@ -6,11 +6,13 @@ from terminusdb_client.errors import DatabaseError
 from terminusdb_client.woqlclient.woqlClient import WOQLClient
 from terminusdb_client.woqlschema.woql_schema import DocumentTemplate, WOQLSchema
 
+test_user_agent = "terminusdb-client-python-tests"
+
 
 def test_create_schema(docker_url, test_schema):
     my_schema = test_schema
     client = WOQLClient(docker_url)
-    client.connect()
+    client.connect(user_agent=test_user_agent)
     client.create_database("test_docapi")
     client.insert_document(
         my_schema, commit_msg="I am checking in the schema", graph_type="schema"
@@ -36,7 +38,7 @@ def test_create_schema(docker_url, test_schema):
 def test_create_schema2(docker_url, test_schema):
     my_schema = test_schema
     client = WOQLClient(docker_url)
-    client.connect()
+    client.connect(user_agent=test_user_agent)
     client.create_database("test_docapi2")
     my_schema.commit(client, "I am checking in the schema")
     result = client.get_all_documents(graph_type="schema")
@@ -85,7 +87,7 @@ def test_insert_cheuk(docker_url, test_schema):
     cheuk.member_of = Team.IT
 
     client = WOQLClient(docker_url)
-    client.connect(db="test_docapi")
+    client.connect(db="test_docapi", user_agent=test_user_agent)
     # client.create_database("test_docapi")
     # print(cheuk._obj_to_dict())
     with pytest.raises(ValueError) as error:
@@ -126,7 +128,7 @@ def test_getting_and_deleting_cheuk(docker_url):
     assert "cheuk" not in globals()
     assert "cheuk" not in locals()
     client = WOQLClient(docker_url)
-    client.connect(db="test_docapi")
+    client.connect(db="test_docapi", user_agent=test_user_agent)
     new_schema = WOQLSchema()
     new_schema.from_db(client)
     cheuk = new_schema.import_objects(
@@ -145,7 +147,7 @@ def test_getting_and_deleting_cheuk(docker_url):
 
 def test_insert_cheuk_again(docker_url, test_schema):
     client = WOQLClient(docker_url)
-    client.connect(db="test_docapi")
+    client.connect(db="test_docapi", user_agent=test_user_agent)
     new_schema = WOQLSchema()
     new_schema.from_db(client)
     uk = new_schema.import_objects(client.get_document("Country/United%20Kingdom"))
@@ -221,7 +223,7 @@ def test_insert_cheuk_again(docker_url, test_schema):
 
 def test_get_data_version(docker_url):
     client = WOQLClient(docker_url)
-    client.connect(db="test_docapi")
+    client.connect(db="test_docapi", user_agent=test_user_agent)
     result, version = client.get_all_branches(get_data_version=True)
     assert version
     result, version = client.get_all_documents(
@@ -301,7 +303,7 @@ def test_datetime_backend(docker_url):
     )
     test_obj = CheckDatetime(datetime=datetime_obj, duration=delta)
     client = WOQLClient(docker_url)
-    client.connect()
+    client.connect(user_agent=test_user_agent)
     client.create_database("test_datetime")
     client.insert_document(CheckDatetime, graph_type="schema")
     client.insert_document(test_obj)
@@ -320,7 +322,7 @@ def test_compress_data(docker_url):
     )
     test_obj = [CheckDatetime(datetime=datetime_obj, duration=delta) for _ in range(10)]
     client = WOQLClient(docker_url)
-    client.connect()
+    client.connect(user_agent=test_user_agent)
     client.create_database("test_compress_data")
     client.insert_document(CheckDatetime, graph_type="schema")
     client.insert_document(test_obj, compress=0)

--- a/terminusdb_client/tests/integration_tests/test_scripts.py
+++ b/terminusdb_client/tests/integration_tests/test_scripts.py
@@ -12,6 +12,8 @@ from terminusdb_client.woqlclient.woqlClient import WOQLClient
 from ...errors import InterfaceError
 from ...scripts import scripts
 
+test_user_agent = "terminusdb-client-python-tests"
+
 
 def _check_csv(csv_file, output):
     with open(csv_file) as file:
@@ -144,7 +146,7 @@ def test_local_happy_path(docker_url, test_csv):
         assert "Schema updated by Python client." in result.output
         # test inherits
         client = WOQLClient(docker_url)
-        client.connect(db=testdb)
+        client.connect(db=testdb, user_agent=test_user_agent)
         schema_objects = [
             {
                 "@type": "Class",

--- a/terminusdb_client/tests/integration_tests/test_scripts.py
+++ b/terminusdb_client/tests/integration_tests/test_scripts.py
@@ -145,8 +145,8 @@ def test_local_happy_path(docker_url, test_csv):
         assert "My message" not in result.output
         assert "Schema updated by Python client." in result.output
         # test inherits
-        client = WOQLClient(docker_url)
-        client.connect(db=testdb, user_agent=test_user_agent)
+        client = WOQLClient(docker_url, user_agent=test_user_agent)
+        client.connect(db=testdb)
         schema_objects = [
             {
                 "@type": "Class",

--- a/terminusdb_client/tests/test_woqlClient.py
+++ b/terminusdb_client/tests/test_woqlClient.py
@@ -41,6 +41,21 @@ def test_connection(mocked_requests):
 
 
 @mock.patch("requests.get", side_effect=mocked_request_success)
+def test_user_agent_set(mocked_requests):
+    woql_client = WOQLClient("http://localhost:6363")
+
+    # before connect it connection is empty
+
+    woql_client.connect(key="root", team="admin", user="admin", user_agent="test_user_agent")
+
+    requests.get.assert_called_once_with(
+        "http://localhost:6363/api/info",
+        auth=("admin", "root"),
+        headers={"user-agent": "test_user_agent"},
+    )
+
+
+@mock.patch("requests.get", side_effect=mocked_request_success)
 def test_connected_flag(mocked_requests):
     woql_client = WOQLClient("http://localhost:6363")
     assert not woql_client._connected

--- a/terminusdb_client/tests/test_woqlClient.py
+++ b/terminusdb_client/tests/test_woqlClient.py
@@ -42,11 +42,11 @@ def test_connection(mocked_requests):
 
 @mock.patch("requests.get", side_effect=mocked_request_success)
 def test_user_agent_set(mocked_requests):
-    woql_client = WOQLClient("http://localhost:6363")
+    woql_client = WOQLClient("http://localhost:6363", user_agent="test_user_agent")
 
     # before connect it connection is empty
 
-    woql_client.connect(key="root", team="admin", user="admin", user_agent="test_user_agent")
+    woql_client.connect(key="root", team="admin", user="admin")
 
     requests.get.assert_called_once_with(
         "http://localhost:6363/api/info",

--- a/terminusdb_client/tests/woqljson/woqlConcatJson.py
+++ b/terminusdb_client/tests/woqljson/woqlConcatJson.py
@@ -1,13 +1,15 @@
 WOQL_CONCAT_JSON = {
     "@type": "Concatenate",
-    "list": {"@type" : "DataValue",
-             "list" : [
-                 {"@type": "DataValue", "variable": "Duration"},
-                 {
-                     "@type": "DataValue",
-                     "data": {"@type": "xsd:string", "@value": " yo "},
-                 },
-                 {"@type": "DataValue", "variable": "Duration_Cast"},
-             ]},
+    "list": {
+        "@type": "DataValue",
+        "list": [
+            {"@type": "DataValue", "variable": "Duration"},
+            {
+                "@type": "DataValue",
+                "data": {"@type": "xsd:string", "@value": " yo "},
+            },
+            {"@type": "DataValue", "variable": "Duration_Cast"},
+        ],
+    },
     "result": {"@type": "DataValue", "variable": "x"},
 }

--- a/terminusdb_client/tests/woqljson/woqlJoinSplitJson.py
+++ b/terminusdb_client/tests/woqljson/woqlJoinSplitJson.py
@@ -1,11 +1,13 @@
 WOQL_JOIN_SPLIT_JSON = {
     "joinJson": {
         "@type": "Join",
-        "list": {"@type": "DataValue",
-                 "list": [
-                     {"@type": "DataValue", "variable": "A_obj"},
-                     {"@type": "DataValue", "variable": "B_obj"},
-                 ]},
+        "list": {
+            "@type": "DataValue",
+            "list": [
+                {"@type": "DataValue", "variable": "A_obj"},
+                {"@type": "DataValue", "variable": "B_obj"},
+            ],
+        },
         "separator": {
             "@type": "DataValue",
             "data": {"@type": "xsd:string", "@value": ", "},

--- a/terminusdb_client/tests/woqljson/woqlJson.py
+++ b/terminusdb_client/tests/woqljson/woqlJson.py
@@ -48,7 +48,7 @@ WOQL_JSON = {
     "groupbyJson": {
         "@type": "GroupBy",
         "group_by": ["A", "B"],
-        'template': [{'@type': 'Value', 'variable': 'C'}],
+        "template": [{"@type": "Value", "variable": "C"}],
         "grouped": {"@type": "Value", "variable": "New"},
         "query": {
             "@type": "Triple",

--- a/terminusdb_client/woqlclient/woqlClient.py
+++ b/terminusdb_client/woqlclient/woqlClient.py
@@ -898,7 +898,7 @@ class WOQLClient:
         for the_arg in add_args:
             if the_arg in kwargs:
                 payload[the_arg] = kwargs[the_arg]
-        headers = self._default_headers
+        headers = self._default_headers.copy()
         headers["X-HTTP-Method-Override"] = "GET"
         result = requests.post(
             self._documents_url(),
@@ -1229,7 +1229,7 @@ class WOQLClient:
         else:
             params["full_replace"] = "false"
 
-        headers = self._default_headers
+        headers = self._default_headers.copy()
         if last_data_version is not None:
             headers["TerminusDB-Data-Version"] = last_data_version
 
@@ -1322,7 +1322,7 @@ class WOQLClient:
         params["graph_type"] = graph_type
         params["create"] = "true" if create else "false"
 
-        headers = self._default_headers
+        headers = self._default_headers.copy()
         if last_data_version is not None:
             headers["TerminusDB-Data-Version"] = last_data_version
 
@@ -1437,7 +1437,7 @@ class WOQLClient:
         params = self._generate_commit(commit_msg)
         params["graph_type"] = graph_type
 
-        headers = self._default_headers
+        headers = self._default_headers.copy()
         if last_data_version is not None:
             headers["TerminusDB-Data-Version"] = last_data_version
 
@@ -1542,7 +1542,7 @@ class WOQLClient:
             request_woql_query = woql_query
         query_obj["query"] = request_woql_query
 
-        headers = self._default_headers
+        headers = self._default_headers.copy()
         if last_data_version is not None:
             headers["TerminusDB-Data-Version"] = last_data_version
 

--- a/terminusdb_client/woqlclient/woqlClient.py
+++ b/terminusdb_client/woqlclient/woqlClient.py
@@ -154,10 +154,12 @@ class WOQLClient:
         Repo identifier of the database that this client is connected to. Default to "local".
     """
 
-    def __init__(self,
-                 server_url: str,
-                 user_agent: str = f"terminusdb-client-python/{__version__}",
-                 **kwargs) -> None:
+    def __init__(
+        self,
+        server_url: str,
+        user_agent: str = f"terminusdb-client-python/{__version__}",
+        **kwargs,
+    ) -> None:
         r"""The WOQLClient constructor.
 
         Parameters
@@ -183,9 +185,7 @@ class WOQLClient:
         self._repo = None
 
         # Default headers
-        self._default_headers = {
-            "user-agent": user_agent
-        }
+        self._default_headers = {"user-agent": user_agent}
 
     @property
     def team(self):
@@ -1593,7 +1593,7 @@ class WOQLClient:
         _finish_response(
             requests.post(
                 self._branch_url(new_branch_id),
-                headers = self._default_headers,
+                headers=self._default_headers,
                 json=source,
                 auth=self._auth(),
             )
@@ -2004,7 +2004,7 @@ class WOQLClient:
             "DocumentTemplate",  # noqa:F821
             List["DocumentTemplate"],  # noqa:F821
         ],
-        document_id: Union[str, None] = None
+        document_id: Union[str, None] = None,
     ):
         """Perform diff on 2 set of document(s), result in a Patch object.
 
@@ -2030,12 +2030,16 @@ class WOQLClient:
                 request_dict[key] = self._convert_diff_dcoument(item)
         if document_id is not None:
             if "before_data_version" in request_dict:
-                if document_id[:len("terminusdb:///data")] == "terminusdb:///data":
+                if document_id[: len("terminusdb:///data")] == "terminusdb:///data":
                     request_dict["document_id"] = document_id
                 else:
-                    raise ValueError(f"Valid document id starts with `terminusdb:///data`, but got {document_id}")
+                    raise ValueError(
+                        f"Valid document id starts with `terminusdb:///data`, but got {document_id}"
+                    )
             else:
-                raise ValueError("`document_id` can only be used in conjusction with a data version or commit ID as `before`, not a document object")
+                raise ValueError(
+                    "`document_id` can only be used in conjusction with a data version or commit ID as `before`, not a document object"
+                )
         if self._connected:
             result = _finish_response(
                 requests.post(

--- a/terminusdb_client/woqlclient/woqlClient.py
+++ b/terminusdb_client/woqlclient/woqlClient.py
@@ -273,7 +273,7 @@ class WOQLClient:
         branch: str = "main",
         ref: Optional[str] = None,
         repo: str = "local",
-        user_agent: str = f"terminusdb-client-python/{__version__}"}
+        user_agent: str = f"terminusdb-client-python/{__version__}",
         **kwargs,
     ) -> None:
         r"""Connect to a Terminus server at the given URI with an API key.

--- a/terminusdb_client/woqlclient/woqlClient.py
+++ b/terminusdb_client/woqlclient/woqlClient.py
@@ -154,13 +154,18 @@ class WOQLClient:
         Repo identifier of the database that this client is connected to. Default to "local".
     """
 
-    def __init__(self, server_url: str, **kwargs) -> None:
+    def __init__(self,
+                 server_url: str,
+                 user_agent: str = f"terminusdb-client-python/{__version__}",
+                 **kwargs) -> None:
         r"""The WOQLClient constructor.
 
         Parameters
         ----------
         server_url : str
             URL of the server that this client will connect to.
+        user_agent: optional, str
+            User agent header when making requests. Defaults to terminusdb-client-python with the version appended.
         \**kwargs
             Extra configuration options
 
@@ -176,6 +181,11 @@ class WOQLClient:
         self._branch = None
         self._ref = None
         self._repo = None
+
+        # Default headers
+        self._default_headers = {
+            "user-agent": user_agent
+        }
 
     @property
     def team(self):
@@ -273,7 +283,6 @@ class WOQLClient:
         branch: str = "main",
         ref: Optional[str] = None,
         repo: str = "local",
-        user_agent: str = f"terminusdb-client-python/{__version__}",
         **kwargs,
     ) -> None:
         r"""Connect to a Terminus server at the given URI with an API key.
@@ -304,8 +313,6 @@ class WOQLClient:
             Ref setting
         repo: optional, str
             Local or remote repo, default to be "local"
-        user_agent: optional, str
-            User agent header when making requests. Defaults to terminusdb-client-python with the version appended.
         \**kwargs
             Extra configuration options.
 
@@ -323,9 +330,6 @@ class WOQLClient:
         self._use_token = use_token
         self._jwt_token = jwt_token
         self._api_token = api_token
-        self._default_headers = {
-            "user-agent": user_agent
-        }
         self.branch = branch
         self.ref = ref
         self.repo = repo

--- a/terminusdb_client/woqlquery/woql_query.py
+++ b/terminusdb_client/woqlquery/woql_query.py
@@ -357,7 +357,7 @@ class WOQLQuery:
         raise ValueError("Subject must be a URI string")
 
     def _clean_predicate(self, predicate):
-        """Transforms whatever is passed in as the predicate (id or variable) into the appropriate json-ld form """
+        """Transforms whatever is passed in as the predicate (id or variable) into the appropriate json-ld form"""
         pred = False
         if type(predicate) is dict:
             return predicate

--- a/terminusdb_client/woqlview/woql_view.py
+++ b/terminusdb_client/woqlview/woql_view.py
@@ -50,7 +50,7 @@ class WOQLView:
         return self
 
     def height(self, height_input: Number):
-        """ Configure height for the WOQLView
+        """Configure height for the WOQLView
 
         Parameters
         ----------
@@ -82,7 +82,7 @@ class WOQLView:
         return self
 
     def edge(self, start: str, end: str):
-        """ Add Edges in the given range
+        """Add Edges in the given range
 
         Parameters
         ----------
@@ -101,7 +101,7 @@ class WOQLView:
         return self
 
     def node(self, *args: str):
-        """ Configure the list of nodes to graph
+        """Configure the list of nodes to graph
 
         Parameters
         ----------
@@ -125,7 +125,7 @@ class WOQLView:
         return self
 
     def text(self, input_text: str):
-        """ Configure text for WOQLView
+        """Configure text for WOQLView
 
         Parameters
         ----------
@@ -143,7 +143,7 @@ class WOQLView:
         return self
 
     def distance(self, input_distance: Number):
-        """ Configure distance for the WOQLView
+        """Configure distance for the WOQLView
 
         Parameters
         ----------
@@ -161,7 +161,7 @@ class WOQLView:
         return self
 
     def weight(self, input_weight: Number):
-        """ Configure weight for the WOQLView
+        """Configure weight for the WOQLView
 
         Parameters
         ----------
@@ -179,7 +179,7 @@ class WOQLView:
         return self
 
     def color(self, input_color: list):
-        """ Configure colors for the WOQLView
+        """Configure colors for the WOQLView
 
         Parameters
         ----------
@@ -204,7 +204,7 @@ class WOQLView:
         return self
 
     def icon(self, input_dict: dict):
-        """ Configure icon for the WOQLView
+        """Configure icon for the WOQLView
 
         Parameters
         ----------
@@ -224,7 +224,7 @@ class WOQLView:
         return self
 
     def size(self, input_size: Number):
-        """ Configure size for the WOQLView
+        """Configure size for the WOQLView
 
         Parameters
         ----------
@@ -242,7 +242,7 @@ class WOQLView:
         return self
 
     def collision_radius(self, input_radius: Number):
-        """ Configure radius for the WOQLView
+        """Configure radius for the WOQLView
 
         Parameters
         ----------
@@ -262,7 +262,7 @@ class WOQLView:
         return self
 
     def hidden(self, input_choice: bool):
-        """ Configure hidden choice for the WOQLView
+        """Configure hidden choice for the WOQLView
 
         Parameters
         ----------
@@ -281,7 +281,7 @@ class WOQLView:
         return self
 
     def charge(self, input_charge: Number):
-        """ Configure charge for the WOQLView
+        """Configure charge for the WOQLView
 
         Parameters
         ----------
@@ -299,7 +299,7 @@ class WOQLView:
         return self
 
     def of(self, input_obj: str):
-        """ Configure IN object for the WOQLView
+        """Configure IN object for the WOQLView
 
         Parameters
         ----------


### PR DESCRIPTION
We want to differentiate tests from statistics from normal client usage. It can also be needed for users of the clients as well to change the user agent as they wish.