### PR TITLE
Fix concurrent running of test

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       TERMINUSX_TOKEN: ${{ secrets.TERMINUSX_TOKEN_DEV }}
     strategy:
+      max-parallel: 1
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 

--- a/terminusdb_client/tests/integration_tests/test_client.py
+++ b/terminusdb_client/tests/integration_tests/test_client.py
@@ -300,7 +300,9 @@ def test_terminusx(terminusx_token):
     os.environ.get("TERMINUSX_TOKEN") is None, reason="TerminusX token does not exist"
 )
 def test_terminusx_crazy_path(terminusx_token):
-    testdb = "test happy_" + str(dt.datetime.now()).replace(" ", "")
+    testdb = (
+        "test_crazy" + str(dt.datetime.now()).replace(" ", "") + "_" + str(random())
+    )
     endpoint = "https://cloud-dev.terminusdb.com/TerminusDBTest/"
     client = WOQLClient(endpoint, user_agent=test_user_agent)
     client.connect(use_token=True, team="TerminusDBTest")

--- a/terminusdb_client/tests/integration_tests/test_client.py
+++ b/terminusdb_client/tests/integration_tests/test_client.py
@@ -282,7 +282,7 @@ def test_jwt(docker_url_jwt):
 def test_terminusx(terminusx_token):
     testdb = (
         "test_happy_" + str(dt.datetime.now()).replace(" ", "") + "_" + str(random())
-    )
+    ).replace(":", "_").replace(".", "")
     endpoint = "https://cloud-dev.terminusdb.com/TerminusDBTest/"
     client = WOQLClient(endpoint, user_agent=test_user_agent)
     client.connect(use_token=True, team="TerminusDBTest")
@@ -302,7 +302,7 @@ def test_terminusx(terminusx_token):
 def test_terminusx_crazy_path(terminusx_token):
     testdb = (
         "test_crazy" + str(dt.datetime.now()).replace(" ", "") + "_" + str(random())
-    )
+    ).replace(":", "_").replace(".", "")
     endpoint = "https://cloud-dev.terminusdb.com/TerminusDBTest/"
     client = WOQLClient(endpoint, user_agent=test_user_agent)
     client.connect(use_token=True, team="TerminusDBTest")


### PR DESCRIPTION
It should have a random element to prevent a non-existing DB from being used if the tests are running concurrently.
