### PR TITLE
tests: add positional argument to allow specific tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     -r requirements.txt
 commands =
     pip install -e .
-    python -m pytest --tb=native --cov=terminusdb_client terminusdb_client/tests/ --cov-report xml:cov.xml
+    python -m pytest --tb=native --cov=terminusdb_client terminusdb_client/tests/{posargs} --cov-report xml:cov.xml
 passenv = TERMINUSX_TOKEN
 
 


### PR DESCRIPTION
For instance, if you only want to test client:

`tox -e test integration_tests/test_client.py`
