### PR TITLE
Implement efficient get_database function

### DIFF
--- a/terminusdb_client/client/Client.py
+++ b/terminusdb_client/client/Client.py
@@ -2705,13 +2705,15 @@ class Client:
         )
         return json.loads(_finish_response(result))
 
-    def get_database(self, dbid: str) -> Optional[dict]:
+    def get_database(self, dbid: str, team: Optional[str] = None) -> Optional[dict]:
         """
         Returns metadata (id, organization, label, comment) about the requested database
         Parameters
         ----------
         dbid : str
             The id of the database
+        team : str
+            The organization of the database (default self.team)
 
         Raises
         ------
@@ -2723,10 +2725,13 @@ class Client:
         dict or None if not found
         """
         self._check_connection(check_db=False)
-        for this_db in self.get_databases():
-            if this_db["name"] == dbid:
-                return this_db
-        return None
+        team = team if team else self.team
+        result = requests.get(
+            f"{self.api}/db/{team}/{dbid}?verbose=true",
+            headers=self._default_headers,
+            auth=self._auth(),
+        )
+        return json.loads(_finish_response(result))
 
     def get_databases(self) -> List[dict]:
         """

--- a/terminusdb_client/tests/integration_tests/test_client.py
+++ b/terminusdb_client/tests/integration_tests/test_client.py
@@ -110,6 +110,17 @@ def test_add_get_remove_org(docker_url):
         client.get_organization("testOrg")
 
 
+def test_get_database(docker_url):
+    client = Client(docker_url, user_agent=test_user_agent, team="admin")
+    client.connect()
+    db_name = "testDB" + str(random())
+    client.create_database(db_name, team="admin")
+    db = client.get_database(db_name)
+    assert db['name'] == db_name
+    db_with_team = client.get_database(db_name, team='admin')
+    assert db_with_team['name'] == db_name
+
+
 def test_add_get_remove_user(docker_url):
     # create client
     client = Client(docker_url, user_agent=test_user_agent)

--- a/terminusdb_client/tests/test_Client.py
+++ b/terminusdb_client/tests/test_Client.py
@@ -167,7 +167,8 @@ def test_crazy_branch(mocked_requests, mocked_requests2, mocked_requests3):
 
 
 @mock.patch("requests.get", side_effect=mocked_request_success)
-def test_get_database(mocked_requests):
+@mock.patch("requests.post", side_effect=mocked_request_success)
+def test_get_database(mocked_requests, mocked_requests2):
     client = Client("http://localhost:6363")
     client.connect(user="admin", team="admin", key="root")
     db_name = "testDB" + str(random.randrange(100000))

--- a/terminusdb_client/tests/test_Client.py
+++ b/terminusdb_client/tests/test_Client.py
@@ -166,6 +166,20 @@ def test_crazy_branch(mocked_requests, mocked_requests2, mocked_requests3):
     )
 
 
+@mock.patch("requests.get", side_effect=mocked_request_success)
+def test_get_database(mocked_requests, mocked_requests2):
+    client = Client("http://localhost:6363")
+    client.connect(user="admin", team="admin", key="root")
+    db_name = "testDB" + str(random.randrange(100000))
+    client.create_database(db_name)
+    client.get_database(db_name)
+    requests.get.assert_called_with(
+        f"http://localhost:6363/api/db/admin/{db_name}?verbose=true",
+        auth=("admin", "root"),
+        headers={"user-agent": f"terminusdb-client-python/{__version__}"},
+    )
+
+
 @pytest.mark.skip(reason="temporary not avaliable")
 @mock.patch("requests.head", side_effect=mocked_request_success)
 @mock.patch("requests.get", side_effect=mocked_request_success)

--- a/terminusdb_client/tests/test_Client.py
+++ b/terminusdb_client/tests/test_Client.py
@@ -167,7 +167,7 @@ def test_crazy_branch(mocked_requests, mocked_requests2, mocked_requests3):
 
 
 @mock.patch("requests.get", side_effect=mocked_request_success)
-def test_get_database(mocked_requests, mocked_requests2):
+def test_get_database(mocked_requests):
     client = Client("http://localhost:6363")
     client.connect(user="admin", team="admin", key="root")
     db_name = "testDB" + str(random.randrange(100000))


### PR DESCRIPTION
I always use the ?verbose=true parameter because it remains backwards compatible with the existing call this way, as every property that was previously fetched is now fetched as well.

Fixes #333 

I ran some tests and it improves performance significantly when there are a lot of databases:

```python3
# The old one
>>> start_time = time.perf_counter(); client.get_database('db8598'); print(time.perf_counter() - start_time)
{'@id': 'UserDatabase/311991b0e98d374525147ba301cbe988afde7a54f469121ee279ac158daa7b2d', '@type': 'UserDatabase', 'comment': 'random db', 'creation_date': '2022-08-19T14:37:14.211Z', 'label': 'db', 'name': 'db8598', 'state': 'finalized'}
0.1862535679993016
# The new one
>>> start_time = time.perf_counter(); test_get_db(); print(time.perf_counter() - start_time)
{'@id': 'UserDatabase/311991b0e98d374525147ba301cbe988afde7a54f469121ee279ac158daa7b2d', '@type': 'UserDatabase', 'branches': ['main'], 'comment': 'random db', 'creation_date': '2022-08-19T14:37:14.211Z', 'label': 'db', 'name': 'db8598', 'path': 'admin/db8598', 'state': 'finalized'}
0.07261596200078202
```