### PR TITLE
fix: WOQLQuery.substr

### DIFF
--- a/terminusdb_client/woqlquery/woql_query.py
+++ b/terminusdb_client/woqlquery/woql_query.py
@@ -1257,7 +1257,7 @@ class WOQLQuery:
         if not substring:
             substring = length
             length = len(substring) + before
-        if not string or not substring or type(substring) != type:
+        if not string or not substring or type(substring) != str:
             raise ValueError(
                 "Substr - the first and last parameters must be strings representing the full and substring variables / literals"
             )


### PR DESCRIPTION
I can't use `WOQLQuery.substr`. I think it's because a string argument is expected to have a `type` of `type` (rather than e.g. of `str`).