### PR TITLE
Set terminusx token only if it is from our repo

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -43,7 +43,7 @@ jobs:
         python -m pip install tox
         tox -e deps
     - name: Set TerminusX token if commit is from our repo
-      if: github.repository == 'terminusdb/terminusdb'
+      if: github.repository == 'terminusdb/terminusdb-client-python'
       run: |
         export TERMINUSX_TOKEN='${{ secrets.TERMINUSX_TOKEN_DEV }}'
     - name: Test with pytest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -27,8 +27,6 @@ jobs:
   build:
     needs: check
     runs-on: ubuntu-latest
-    env:
-      TERMINUSX_TOKEN: ${{ secrets.TERMINUSX_TOKEN_DEV }}
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
@@ -44,6 +42,10 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install tox
         tox -e deps
+    - name: Set TerminusX token if commit is from our repo
+      if: github.repository == 'terminusdb/terminusdb'
+      run: |
+        export TERMINUSX_TOKEN='${{ secrets.TERMINUSX_TOKEN_DEV }}'
     - name: Test with pytest
       run: |
         tox -e test

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -44,7 +44,7 @@ jobs:
         tox -e deps
     - name: Test with pytest
       run: |
-        [[ "$GITHUB_REPOSITORY" == "terminusdb/terminusdb-client-python" ]] && export TERMINUSX_TOKEN='${{ secrets.TERMINUSX_TOKEN_DEV }}'
+        [[ "$GITHUB_REPOSITORY" == "terminusdb/terminusdb-client-python" && "$GITHUB_EVENT_NAME" == "push" ]] && export TERMINUSX_TOKEN='${{ secrets.TERMINUSX_TOKEN_DEV }}'
         tox -e test
     - name: Coverage report
       uses: codecov/codecov-action@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,12 +42,9 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install tox
         tox -e deps
-    - name: Set TerminusX token if commit is from our repo
-      if: github.repository == 'terminusdb/terminusdb-client-python'
-      run: |
-        export TERMINUSX_TOKEN='${{ secrets.TERMINUSX_TOKEN_DEV }}'
     - name: Test with pytest
       run: |
+        [[ "$GITHUB_REPOSITORY" == "terminusdb/terminusdb-client-python" ]] && export TERMINUSX_TOKEN='${{ secrets.TERMINUSX_TOKEN_DEV }}'
         tox -e test
     - name: Coverage report
       uses: codecov/codecov-action@v2


### PR DESCRIPTION
Otherwise it prevents PRs from forked repos to run the tests correctly. Since they can't access the secret TerminusX token.