### PR TITLE
Fix int marshalling

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # TerminusDB Python Client Release Notes
 
+## v10.2.1
+
+### Bug fixes
+
+- Fix integer marshalling in schema with TerminusDB 11
+
 ## v10.2.0
 
 ### New

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "terminusdb-client"
-version = "10.2.0"
+version = "10.2.1"
 description = "Python client for Terminus DB"
 authors = ["TerminusDB group"]
 license = "Apache Software License"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ extras_require = {"dataframe": ["numpy >= 1.13.0", "pandas >= 0.23.0"]}
 
 setuptools.setup(
     name="terminusdb-client",
-    version="10.2.0",
+    version="10.2.1",
     author="TerminusDB group",
     author_email="terminusdatabase@gmail.com",
     description="Python client for Terminus DB",

--- a/terminusdb_client/__version__.py
+++ b/terminusdb_client/__version__.py
@@ -1,7 +1,7 @@
 __title__ = "woqlClient"
 __description__ = "woqlClient library for accessing the Terminus DB API"
 __url__ = ""
-__version__ = "10.2.0"
+__version__ = "10.2.1"
 __build__ = 00
 __author__ = "TerminusDB group"
 __author_email__ = "team@terminusdb.com"

--- a/terminusdb_client/schema/schema.py
+++ b/terminusdb_client/schema/schema.py
@@ -67,6 +67,8 @@ def _check_mismatch_type(prop, prop_value, prop_type):
                 f"Property {prop} should be of type {prop_type_id} but got value of type {prop_value_id}"
             )
     else:
+        if prop_type == int:
+            prop_value = int(prop_value)
         check_type(prop, prop_value, prop_type)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     --no-deps
     -r requirements.txt
 commands =
-    pip install -e .
+#    pip install -e .
     python -m pytest --tb=native --cov=terminusdb_client terminusdb_client/tests/{posargs} --cov-report xml:cov.xml
 passenv = TERMINUSX_TOKEN
 


### PR DESCRIPTION
The int marshalling had to be changed in order to work with TerminusDB 11's handling of larger numbers.