### PR TITLE
Always pull image for testing

### DIFF
--- a/terminusdb_client/tests/integration_tests/test-docker-compose.yml
+++ b/terminusdb_client/tests/integration_tests/test-docker-compose.yml
@@ -7,6 +7,7 @@ services:
   terminusdb-server:
     image: terminusdb/terminusdb-server:dev
     container_name: terminusdb-server
+    pull_policy: always
     hostname: terminusdb-server
     tty: true
     ports:


### PR DESCRIPTION
This prevents running tests accidentally with ancient versions of TerminusDB