### PR TITLE
Fix conversion of sys:JSON type schema to Python

### DIFF
--- a/terminusdb_client/tests/test_Schema.py
+++ b/terminusdb_client/tests/test_Schema.py
@@ -206,6 +206,27 @@ def test_embedded_object(test_schema):
     assert (len(result) == 2)
 
 
+def test_person_sys_json():
+    schema_json = {
+        "@id": "PersonJSONTest",
+        "@key": {
+            "@type": "Random"
+        },
+        "@type": "Class",
+        "metadata": {
+            "@class": "sys:JSON",
+            "@type": "Optional"
+        }
+    }
+    schema = Schema()
+    test_result = schema._construct_class(schema_json)
+    result = {'@id': 'PersonJSONTest',
+              '@key': {'@type': 'Random'},
+              '@type': 'Class',
+              'metadata': {'@class': 'sys:JSON', '@type': 'Optional'}}
+    assert test_result._to_dict() == result
+
+
 def test_id_and_capture(test_schema):
     my_schema = test_schema
     Person = my_schema.object.get("Person")

--- a/terminusdb_client/woql_type.py
+++ b/terminusdb_client/woql_type.py
@@ -7,6 +7,7 @@ CONVERT_TYPE = {
     bool: "xsd:boolean",
     float: "xsd:double",
     int: "xsd:integer",
+    dict: "sys:JSON",
     dt.datetime: "xsd:dateTime",
     dt.date: "xsd:date",
     dt.time: "xsd:time",


### PR DESCRIPTION
If a class contained a "sys:JSON" property, it wouldn't convert to a normal Python class as it should.

Fixes issue #397
