### PR TITLE
allow redirects for has_database head request

### DIFF
--- a/terminusdb_client/client/Client.py
+++ b/terminusdb_client/client/Client.py
@@ -2886,6 +2886,7 @@ class Client:
             f"{self.api}/db/{team}/{dbid}",
             headers=self._default_headers,
             auth=self._auth(),
+            allow_redirects=True,
         )
         return r.status_code == 200
 


### PR DESCRIPTION
The immediate response code is 308, not 200.

I haven't created a corresponding bug report, but without this change, `has_database` fails because the response code is not 200.
