### PR TITLE
Upgrade to docker compose v2

### DIFF
--- a/terminusdb_client/tests/integration_tests/conftest.py
+++ b/terminusdb_client/tests/integration_tests/conftest.py
@@ -42,7 +42,8 @@ def docker_url_jwt(pytestconfig):
     pytestconfig.getoption("docker_compose")
     output = subprocess.run(
         [
-            "docker-compose",
+            "docker",
+            "compose",
             "--file",
             os.path.dirname(os.path.realpath(__file__))
             + "/test-docker-compose-jwt.yml",
@@ -61,7 +62,8 @@ def docker_url_jwt(pytestconfig):
     while not is_server_started:
         service = subprocess.run(
             [
-                "docker-compose",
+                "docker",
+                "compose",
                 "--file",
                 os.path.dirname(os.path.realpath(__file__))
                 + "/test-docker-compose-jwt.yml",
@@ -100,7 +102,8 @@ def docker_url(pytestconfig):
     pytestconfig.getoption("docker_compose")
     output = subprocess.run(
         [
-            "docker-compose",
+            "docker",
+            "compose",
             "--file",
             os.path.dirname(os.path.realpath(__file__)) + "/test-docker-compose.yml",
             "up",
@@ -118,7 +121,8 @@ def docker_url(pytestconfig):
     while not is_server_started:
         service = subprocess.run(
             [
-                "docker-compose",
+                "docker",
+                "compose",
                 "--file",
                 os.path.dirname(os.path.realpath(__file__))
                 + "/test-docker-compose.yml",
@@ -153,7 +157,8 @@ def docker_url(pytestconfig):
 def clean_up_container():
     subprocess.run(
         [
-            "docker-compose",
+            "docker",
+            "compose",
             "--file",
             os.path.dirname(os.path.realpath(__file__)) + "/test-docker-compose.yml",
             "down",
@@ -162,7 +167,8 @@ def clean_up_container():
     )
     subprocess.run(
         [
-            "docker-compose",
+            "docker",
+            "compose",
             "--file",
             os.path.dirname(os.path.realpath(__file__)) + "/test-docker-compose.yml",
             "rm",
@@ -174,7 +180,8 @@ def clean_up_container():
     )
     subprocess.run(
         [
-            "docker-compose",
+            "docker",
+            "compose",
             "--file",
             os.path.dirname(os.path.realpath(__file__))
             + "/test-docker-compose-jwt.yml",
@@ -184,7 +191,8 @@ def clean_up_container():
     )
     subprocess.run(
         [
-            "docker-compose",
+            "docker",
+            "compose",
             "--file",
             os.path.dirname(os.path.realpath(__file__))
             + "/test-docker-compose-jwt.yml",
@@ -195,8 +203,8 @@ def clean_up_container():
         ],
         check=True,
     )
-    subprocess.run(["docker-compose", "down"])
-    subprocess.run(["docker-compose", "rm", "--force", "--stop", "-v"])
+    subprocess.run(["docker", "compose", "down"])
+    subprocess.run(["docker", "compose", "rm", "--force", "--stop", "-v"])
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Since July 2023, `docker-compose` is [not receiving updates](https://docs.docker.com/compose/migrate/) anymore, and should be replaced with `docker compose` (space instead of `-`).

This PR just replaces occurrences of the old call with the new one. Tests should just work, as they're already using a current version of docker.