### PR TITLE
Aligned WOQL AST to DeletedTriple (fixes #434)

### DIFF
--- a/terminusdb_client/woqlquery/woql_query.py
+++ b/terminusdb_client/woqlquery/woql_query.py
@@ -1016,7 +1016,7 @@ class WOQLQuery:
             return self.opt().triple(sub, pred, obj)
         if self._cursor.get("@type"):
             self._wrap_cursor_with_and()
-        self._cursor["@type"] = "RemovedTriple"
+        self._cursor["@type"] = "DeletedTriple"
         self._cursor["subject"] = self._clean_subject(sub)
         self._cursor["predicate"] = self._clean_predicate(pred)
         self._cursor["object"] = self._clean_object(obj)


### PR DESCRIPTION
This clears up the AST inconsistency and makes remove_triple work again.
